### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 A collection of tools that allow AI assistants like Claude to interact with Apple applications and services through the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/@wearesage/mcp-apple">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wearesage/mcp-apple/badge" alt="Apple Tools MCP server" />
+</a>
+
 ## Overview
 
-This package provides MCP tools for interacting with various Apple applications and services, including:
+This package provides MCP tools for interacting with various Apple applications and services, including: 
 
 - **Contacts**: Search and retrieve contacts from Apple Contacts app
 - **Notes**: Search, retrieve, create notes, and list folders in Apple Notes app


### PR DESCRIPTION
This PR adds a badge for the [Apple MCP Tools](https://glama.ai/mcp/servers/@wearesage/mcp-apple) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@wearesage/mcp-apple">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wearesage/mcp-apple/badge" alt="Apple Tools MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.